### PR TITLE
Add glvec color format

### DIFF
--- a/data/com.github.finefindus.eyedropper.gschema.xml.in
+++ b/data/com.github.finefindus.eyedropper.gschema.xml.in
@@ -14,7 +14,7 @@
       <summary>Window maximized state</summary>
     </key>
     <key name="format-order" type="as">
-      <default>[ 'name', 'hex', 'rgb', 'hsl', 'hsv', 'cmyk', 'xyz', 'cielab', 'hwb', 'hcl', 'lms', 'hunterlab' ]</default>
+      <default>[ 'name', 'hex', 'rgb', 'hsl', 'hsv', 'cmyk', 'xyz', 'cielab', 'hwb', 'hcl', 'lms', 'glvec', 'hunterlab' ]</default>
       <summary>Format Order</summary>
       <description>Order, in which the available formats are displayed.</description>
     </key>
@@ -82,6 +82,11 @@
       <default>false</default>
       <summary>Show LMS format</summary>
       <description>Changes the visibility of the LMS format.</description>
+    </key>
+    <key name="show-glvec-format" type="b">
+      <default>false</default>
+      <summary>Show glvec format</summary>
+      <description>Changes the visibility of the glvec format.</description>
     </key>
     <key name="show-hunter-lab-format" type="b">
       <default>false</default>
@@ -172,6 +177,11 @@
       <default>''</default>
       <summary>Custom LMS format</summary>
       <description>A user set format for LMS. If it's empty, the default format will be used.</description>
+    </key>
+    <key name="custom-format-glvec" type="s">
+      <default>''</default>
+      <summary>Custom glvec format</summary>
+      <description>A user set format for glvec. If it's empty, the default format will be used.</description>
     </key>
     <key name="custom-format-hunter-lab" type="s">
       <default>''</default>

--- a/data/resources/ui/preferences.ui
+++ b/data/resources/ui/preferences.ui
@@ -235,6 +235,13 @@
                         </child>
                         <child>
                             <object class="CustomFormatRow">
+                                <property name="title" translatable="yes">Glvec Format</property>
+                                <property name="default-format">vec4({r}, {g}, {b}, {a})</property>
+                                <property name="settings-key">custom-format-glvec</property>
+                            </object>
+                        </child>
+                        <child>
+                            <object class="CustomFormatRow">
                                 <property name="title" translatable="yes">Hunter Lab Format</property>
                                 <property name="default-format">L: {l}, a: {a}, b: {b}</property>
                                 <property name="settings-key">custom-format-hunter-lab</property>

--- a/data/resources/ui/window.ui
+++ b/data/resources/ui/window.ui
@@ -208,6 +208,12 @@
                               </object>
                             </child>
                             <child>
+                              <object class="ColorFormatRow" id="glvec_row">
+                                <property name="tooltip" translatable="yes">Copy glvec</property>
+                                <property name="visible">False</property>
+                              </object>
+                            </child>
+                            <child>
                               <object class="ColorFormatRow" id="hunter_lab_row">
                                 <property name="tooltip" translatable="yes">Copy Hunter Lab</property>
                                 <property name="visible">False</property>

--- a/src/colors/formatter.rs
+++ b/src/colors/formatter.rs
@@ -344,6 +344,35 @@ impl ColorFormatter {
             precision = self.precision()
         )
     }
+
+    /// Format the color as glvec
+    pub fn glvec(&self) -> String {
+        custom_format!(
+            self.custom_format("custom-format-glvec"),
+            ("r", self.color.red as f32 / 255.0),
+            ("g", self.color.green as f32 / 255.0),
+            ("b", self.color.blue as f32 / 255.0),
+            ("a", self.color.alpha as f32 / 255.0)
+        );
+        match self.alpha_position {
+            // show alpha at the end (rgba)
+            AlphaPosition::End => format!(
+                "vec4({}, {}, {}, {})",
+                self.color.red as f32 / 255.0,
+                self.color.green as f32 / 255.0,
+                self.color.blue as f32 / 255.0,
+                self.color.alpha as f32 / 255.0
+            ),
+            // no alpha / there is no argb
+            _ => format!(
+                "vec3({}, {}, {})",
+                self.color.red as f32 / 255.0,
+                self.color.green as f32 / 255.0,
+                self.color.blue as f32 / 255.0
+            ),
+        }
+    }
+
     /// Format the color as hunter-lab.
     pub fn hunter_lab(&self) -> String {
         let (l, a, b) = self

--- a/src/widgets/preferences_window.rs
+++ b/src/widgets/preferences_window.rs
@@ -499,6 +499,12 @@ impl PreferencesWindow {
                 "lms" => {
                     ColorFormatObject::new(item, gettext("LMS"), formatter.lms(), "show-lms-format")
                 }
+                "glvec" => ColorFormatObject::new(
+                    item,
+                    gettext("glvec"),
+                    formatter.glvec(),
+                    "show-glvec-format",
+                ),
                 "hunterlab" => ColorFormatObject::new(
                     item,
                     gettext("Hunter Lab"),

--- a/src/window.rs
+++ b/src/window.rs
@@ -62,6 +62,8 @@ mod imp {
         #[template_child]
         pub lms_row: TemplateChild<widgets::color_format_row::ColorFormatRow>,
         #[template_child]
+        pub glvec_row: TemplateChild<widgets::color_format_row::ColorFormatRow>,
+        #[template_child]
         pub hunter_lab_row: TemplateChild<widgets::color_format_row::ColorFormatRow>,
         #[template_child]
         pub history_list: TemplateChild<gtk::ListBox>,
@@ -92,6 +94,7 @@ mod imp {
                 hcl_row: TemplateChild::default(),
                 name_row: TemplateChild::default(),
                 lms_row: TemplateChild::default(),
+                glvec_row: TemplateChild::default(),
                 history_list: TemplateChild::default(),
                 history: Default::default(),
                 settings: gio::Settings::new(APP_ID),
@@ -406,6 +409,7 @@ impl AppWindow {
         settings.connect_changed(Some("custom-format-hwb"), update_color.clone());
         settings.connect_changed(Some("custom-format-hcl"), update_color.clone());
         settings.connect_changed(Some("custom-format-lms"), update_color.clone());
+        settings.connect_changed(Some("custom-format-glvec"), update_color.clone());
         settings.connect_changed(Some("custom-format-hunter-lab"), update_color);
 
         imp.hex_row.set_settings_name("show-hex-format");
@@ -418,6 +422,7 @@ impl AppWindow {
         imp.hwb_row.set_settings_name("show-hwb-format");
         imp.hcl_row.set_settings_name("show-hcl-format");
         imp.lms_row.set_settings_name("show-lms-format");
+        imp.glvec_row.set_settings_name("show-glvec-format");
         imp.hunter_lab_row
             .set_settings_name("show-hunter-lab-format");
         imp.name_row.set_settings_name("show-color-name");
@@ -497,6 +502,7 @@ impl AppWindow {
                 "hcl" => &imp.hcl_row,
                 "name" => &imp.name_row,
                 "lms" => &imp.lms_row,
+                "glvec" => &imp.glvec_row,
                 "hunterlab" => &imp.hunter_lab_row,
                 _ => {
                     log::error!("Failed to find format: {}", item);
@@ -635,6 +641,8 @@ impl AppWindow {
 
         imp.lms_row.set_text(formatter.lms());
 
+        imp.glvec_row.set_text(formatter.glvec());
+
         imp.hunter_lab_row.set_text(formatter.hunter_lab());
     }
 
@@ -669,6 +677,8 @@ impl AppWindow {
         imp.name_row
             .connect_closure("copied-text", false, show_toast_closure.clone());
         imp.lms_row
+            .connect_closure("copied-text", false, show_toast_closure.clone());
+        imp.glvec_row
             .connect_closure("copied-text", false, show_toast_closure.clone());
         imp.hunter_lab_row
             .connect_closure("copied-text", false, show_toast_closure);


### PR DESCRIPTION
rgb / rgba format with float values between 0.0-1.0 

can be used for shaders as vec3 / vec4
also can be configured as gdk::RGBA::new({r}, {g}, {b}, {a})

![image](https://user-images.githubusercontent.com/63008755/227030221-1522f4bc-d994-4a19-9abd-c4ac825cc70b.png)
